### PR TITLE
Improved PWA refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,15 +9,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root" class="relative z-20"></div>
+    <div id="twitch" class="w-screen h-screen absolute inset-0 z-10"></div>
 
     <script src="/src/index.tsx" type="module"></script>
-    <!-- <iframe
-      src="https://player.twitch.tv/?channel=thesniper_aoe&parent=localhost"
-      height="100%"
-      width="100%"
-      allowfullscreen
-      class="w-screen h-screen absolute inset-0 z-10 pointer-events-none"
-    >
-    </iframe> -->
   </body>
 </html>

--- a/src/TwitchPlayer.tsx
+++ b/src/TwitchPlayer.tsx
@@ -1,0 +1,19 @@
+
+import {
+  Component,
+  ComponentProps,
+} from "solid-js";
+
+export const TwitchPlayer: Component<ComponentProps<"iframe">& { channel: string }> = (props) => {
+    return (
+      <iframe
+      src={`https://player.twitch.tv/?channel=${props.channel}&parent=${window.location.host}`}
+      height="100%"
+      width="100%"
+      allowfullscreen
+      class="w-screen h-screen absolute inset-0 z-10 pointer-events-none"
+    >
+    </iframe>
+    );
+  };
+  

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,11 @@
 /* @refresh reload */
 import './index.css';
 import { render } from 'solid-js/web';
+import { registerSW } from 'virtual:pwa-register';
 
 import App from './App';
 
 render(() => <App />, document.getElementById('root') as HTMLElement);
+
+// Registers the serviceworker and will autoUpdate it on page load, then if there's an update refresh the page.
+registerSW({ immediate: true });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,8 +4,15 @@ import { render } from 'solid-js/web';
 import { registerSW } from 'virtual:pwa-register';
 
 import App from './App';
+import { TwitchPlayer } from './TwitchPlayer';
 
 render(() => <App />, document.getElementById('root') as HTMLElement);
+
+const options = new URLSearchParams(window.location.search);
+const twitch = options.get("twitch");
+if (twitch) {
+  render(() => <TwitchPlayer channel={twitch} />, document.getElementById('twitch') as HTMLElement);
+}
 
 // Registers the serviceworker and will autoUpdate it on page load, then if there's an update refresh the page.
 registerSW({ immediate: true });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       workbox: {
-        globPatterns: ['index.html', '*.js', 'assets/*.*']
+        globPatterns: ['index.html', 'assets/*.*']
       }
     })
   ],


### PR DESCRIPTION
In previous version, a streamer would have to refresh page twice. once to force update check of service worker, and second time to reload page to actually apply it.
With the embedded code, it'll auto-reload the page if a serviceworker update was detected.
Note that this version will not periodically 'check' for updates, even though that's easily added.

Also moved the commented out embedded twitch viewer to a query param.
